### PR TITLE
Fix Worker Permissions Issue

### DIFF
--- a/templates/rffmpeg-deployment.yaml
+++ b/templates/rffmpeg-deployment.yaml
@@ -22,7 +22,7 @@ spec:
           imagePullPolicy: {{ .image.pullPolicy }}
           env:
             - name: SSH_USERS
-              value: "kah:1000:1000"
+              value: "kah:568:568"
             - name: TZ
               value: {{ .timezone }}
           ports:


### PR DESCRIPTION
I found a permission denied error in jellyfins pod logs that wasn't in the logs that it dumps. Using that information, I found out the kah user is 568 in the jellyfin instance not 1000.

Issue I opened with logs
https://github.com/aleksasiriski/rffmpeg-go/issues/21